### PR TITLE
fix: many 404s

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,22 +24,22 @@ Built on next, the pages live in `src/app`. See https://nextjs.org/docs/app
 
 ## Docs
 
-Add pages as markdown with .md extension to `src/pages/docs`
+Add pages as markdown with .md extension to `src/pages`
 
-The path to the file is used as the url, e.g. `src/pages/docs/w3cli.md` -> `/docs/w3cli`.
+The path to the file is used as the url, e.g. `src/pages/w3cli.mdx` -> `/w3cli`.
 
 The `_meta.json` in the directory defines the order of links in the sidebar and the values set their link text.
 
 Update the `_meta.json` file in the directory when you add a new page. There should be one in each sub directory.
 
 
-`src/pages/docs/_meta.json`
+`src/pages/_meta.json`
 ```json
 {
   "index": "Welcome",
   "w3cli": "Command line",
   "w3up-client": "JS Client",
-  "concepts": "Concepts"
+  "concepts": "Concepts",
   "pail": {
     "display": "hidden",
     "title": "future tech"
@@ -63,7 +63,7 @@ To link to other pages using the root relative url in a standard markdown link. 
 
 **quickstart.md**
 ```md
-[try the w3cli](/docs/w3cli)
+[try the w3cli](/w3cli)
 ```
 
 ### Images
@@ -72,5 +72,5 @@ To show an image you compress the image ready for use on the web, then save it t
 
 **quickstart.md**
 ```md
-![screenshot of console uploads list](/docs/console-uploads-list.png)
+![screenshot of console uploads list](/console-uploads-list.png)
 ```

--- a/src/pages/concepts/architecture-options.mdx
+++ b/src/pages/concepts/architecture-options.mdx
@@ -25,7 +25,7 @@ w3up-client in backend-\>\>storacha w3up service: Upload data
 You'll need a registered Space, and your client in the backend to have a delegation to use the Space.
 
 <Callout>
-  **Recommended**: It's easiest to create and register your Space using [w3cli](https://github.com/storacha/w3cli), then create an identity for your server and delegate it the ability to upload to your Space. The [bring your own delegations](/docs/how-to/upload/#bring-your-own-delegations) section shows how to generate an identity, create a delegation and then use it on the server.
+  **Recommended**: It's easiest to create and register your Space using [w3cli](https://github.com/storacha/w3cli), then create an identity for your server and delegate it the ability to upload to your Space. The [bring your own delegations](/how-to/upload/#bring-your-own-delegations) section shows how to generate an identity, create a delegation and then use it on the server.
 </Callout>
 
 After this, once your user uploads data to your backend, you can run any of the upload methods.
@@ -53,7 +53,7 @@ Typically `w3up-client` will be running in your end-user's client code, as well 
 You'll need a registered Space, and your client in the backend to have a delegation to use the Space.
 
 <Callout>
-  **Recommended**: It's easiest to create and register your Space using [w3cli](https://github.com/storacha/w3cli), then create an identity for your server and delegate it the ability to upload to your Space. The [bring your own delegations](/docs/how-to/upload/#bring-your-own-delegations) section shows how to generate an identity, create a delegation and then use it on the server.
+  **Recommended**: It's easiest to create and register your Space using [w3cli](https://github.com/storacha/w3cli), then create an identity for your server and delegate it the ability to upload to your Space. The [bring your own delegations](/how-to/upload/#bring-your-own-delegations) section shows how to generate an identity, create a delegation and then use it on the server.
 </Callout>
 
 Your backend code can then re-delegate it's capabilities to your users. Your user does not need a registered Space - just an Agent with a delegation from your Space.

--- a/src/pages/concepts/car.md
+++ b/src/pages/concepts/car.md
@@ -85,15 +85,13 @@ ipfs dag import path/to/input.car
 
 ### `ipfs-car`
 
-The [`ipfs-car`](https://github.com/storacha/ipfs-car) package includes library functions for packing and unpacking files into CARs, using the IPFS UnixFs data model. The library includes the same functionality as the ipfs-car command line utility [described above](/how-tos/work-with-car-files/#ipfs-car).
+The [`ipfs-car`](https://github.com/storacha/ipfs-car) package includes library functions for packing and unpacking files into CARs, using the IPFS UnixFs data model. The library includes the same functionality as the ipfs-car command line utility [described above](/concepts/car/#ipfs-car).
 
 See the `ipfs-car` [README](https://github.com/storacha/ipfs-car#api) for API documentation and usage examples.
 
 ### `@ipld/car`
 
-The [`@ipld/car`](https://github.com/ipld/js-car) package contains the main JavaScript implementation of the CAR specification and is used by ipfs-car under the hood. If you want to store non-file data using [advanced IPLD formats](/how-tos/work-with-car-files/#advanced-ipld-formats), you should use @ipld/car directly.
-
-@ipld/car also provides the CarReader interface used by the Storacha client's [putCar](/reference/js-client-library/#store-car-files)[method](/reference/js-client-library/#store-car-files).
+The [`@ipld/car`](https://github.com/ipld/js-car) package contains the main JavaScript implementation of the CAR specification and is used by ipfs-car under the hood. If you want to store non-file data using [advanced IPLD formats](/concepts/car/#advanced-ipld-formats), you should use `@ipld/car` directly.
 
 Here's a simple example of loading a CAR file from a Node.js stream and storing it with Storacha:
 

--- a/src/pages/concepts/car.md
+++ b/src/pages/concepts/car.md
@@ -6,7 +6,7 @@ For most use cases, you never need to know about this process, as the conversion
 
 ## What is a Content Archive?
 
-The [Content Archive format](https://ipld.io/specs/transport/car/) is a way of packaging up [content addressed data](https://storacha.network/docs/concepts/content-addressing/) into archive files that can be easily stored and transferred. You can think of them like [TAR files](https://en.wikipedia.org/wiki/Tar_\(computing\)) that are designed for storing collections of content addressed data.
+The [Content Archive format](https://ipld.io/specs/transport/car/) is a way of packaging up [content addressed data](https://docs.storacha.network/concepts/content-addressing/) into archive files that can be easily stored and transferred. You can think of them like [TAR files](https://en.wikipedia.org/wiki/Tar_\(computing\)) that are designed for storing collections of content addressed data.
 
 The type of data stored in CARs is defined by [IPLD](https://ipld.io/), or InterPlanetary Linked Data. IPLD is a specification and set of implementations for structured data types that can link to each other using a hash-based Content Identifier (CID). Data linked in this way forms a Directed Acyclic Graph, or DAG, and you'll likely see a few references to DAGs in the documentation for IPLD and IPFS.
 
@@ -85,15 +85,15 @@ ipfs dag import path/to/input.car
 
 ### `ipfs-car`
 
-The [`ipfs-car`](https://github.com/storacha/ipfs-car) package includes library functions for packing and unpacking files into CARs, using the IPFS UnixFs data model. The library includes the same functionality as the ipfs-car command line utility [described above](https://storacha.network/docs/how-tos/work-with-car-files/#ipfs-car).
+The [`ipfs-car`](https://github.com/storacha/ipfs-car) package includes library functions for packing and unpacking files into CARs, using the IPFS UnixFs data model. The library includes the same functionality as the ipfs-car command line utility [described above](/how-tos/work-with-car-files/#ipfs-car).
 
 See the `ipfs-car` [README](https://github.com/storacha/ipfs-car#api) for API documentation and usage examples.
 
 ### `@ipld/car`
 
-The [`@ipld/car`](https://github.com/ipld/js-car) package contains the main JavaScript implementation of the CAR specification and is used by ipfs-car under the hood. If you want to store non-file data using [advanced IPLD formats](https://storacha.network/docs/how-tos/work-with-car-files/#advanced-ipld-formats), you should use @ipld/car directly.
+The [`@ipld/car`](https://github.com/ipld/js-car) package contains the main JavaScript implementation of the CAR specification and is used by ipfs-car under the hood. If you want to store non-file data using [advanced IPLD formats](/how-tos/work-with-car-files/#advanced-ipld-formats), you should use @ipld/car directly.
 
-@ipld/car also provides the CarReader interface used by the Storacha client's [putCar](https://storacha.network/docs/reference/js-client-library/#store-car-files)[method](https://storacha.network/docs/reference/js-client-library/#store-car-files).
+@ipld/car also provides the CarReader interface used by the Storacha client's [putCar](/reference/js-client-library/#store-car-files)[method](/reference/js-client-library/#store-car-files).
 
 Here's a simple example of loading a CAR file from a Node.js stream and storing it with Storacha:
 

--- a/src/pages/concepts/content-addressing.md
+++ b/src/pages/concepts/content-addressing.md
@@ -4,9 +4,9 @@ Storacha's decentralized file storage relies on _content addressing_ to find, re
 
 ## The basic problem
 
-Consider what happens when you resolve a link like `storacha.network/docs/concepts/content-addressing`. First, your operating system queries a global shared key-value store, split into many domains — you may know this as the Domain Name System (DNS). The DNS returns an IP address that your network card can use to send HTTP requests over the network, where this site's naming conventions turn the key `/docs/concepts/content-addressing` into a response payload.
+Consider what happens when you resolve a link like `docs.storacha.network/concepts/content-addressing`. First, your operating system queries a global shared key-value store, split into many domains — you may know this as the Domain Name System (DNS). The DNS returns an IP address that your network card can use to send HTTP requests over the network, where this site's naming conventions turn the key `/concepts/content-addressing` into a response payload.
 
-The problem is, components of an address like `storacha.network/docs/concepts/content-addressing` are _mutable_, meaning they can change over time. In the context of the web, where _everything_ is mutable and dynamic, this is just the way it's always been. As a result, [link rot](https://en.wikipedia-on-ipfs.org/wiki/Link_rot) is just something we've all learned to live with.
+The problem is, components of an address like `docs.storacha.network/concepts/content-addressing` are _mutable_, meaning they can change over time. In the context of the web, where _everything_ is mutable and dynamic, this is just the way it's always been. As a result, [link rot](https://en.wikipedia-on-ipfs.org/wiki/Link_rot) is just something we've all learned to live with.
 
 ## CIDs: Location-independent, globally unique keys
 

--- a/src/pages/concepts/ipfs-gateways.md
+++ b/src/pages/concepts/ipfs-gateways.md
@@ -8,7 +8,7 @@ To make IPFS data accessible outside of the peer-to-peer network, [special IPFS 
 
 As more browsers like [Brave](https://brave.com/ipfs-support/) and [Opera](https://blogs.opera.com/tips-and-tricks/2021/02/opera-crypto-files-for-keeps-ipfs-unstoppable-domains/) adopt native IPFS support, the need for gateways will naturally lessen over time. Today, you can reach the widest audience by using HTTP gateways in your web applications, but it's a great idea to also surface the original ipfs:// URI for your content, so that IPFS-native browsers can access the content directly through Bitswap.
 
-For more information about fetching content that you uploaded through an IPFS HTTP gateway, see the [Retrieve section](/docs/how-to/retrieve).
+For more information about fetching content that you uploaded through an IPFS HTTP gateway, see the [Retrieve section](/how-to/retrieve).
 
 ## Types of gateway
 

--- a/src/pages/concepts/podsi.mdx
+++ b/src/pages/concepts/podsi.mdx
@@ -79,7 +79,7 @@ A data aggregation proof is a [PoDSI](#proof-of-data-segment-inclusion-podsi), _
 
 ## Verifiable Aggregation Pipeline
 
-The Storacha aggregation pipeline is fully verifiable thanks to [UCAN](/docs/concepts/ucans-and-storacha)s. Your piece can be tracked through the pipeline via signed UCAN receipts.
+The Storacha aggregation pipeline is fully verifiable thanks to [UCAN](/concepts/ucans-and-storacha)s. Your piece can be tracked through the pipeline via signed UCAN receipts.
 
 There are 4 roles in the aggregation pipeline:
 

--- a/src/pages/concepts/ucan.md
+++ b/src/pages/concepts/ucan.md
@@ -290,7 +290,7 @@ Note that the `w3 delegation create` command we used in step 5 delegates the `'*
 
 UCAN delegation is a powerful tool for managing access to your w3up resources. Hopefully this post has given you some ideas about how delegation can help you build out new experiences using w3up.
 
-Thanks for following along, and feel free to [get in touch](https://storacha.network/docs/community/help-and-support/) if you have any questions!
+Thanks for following along, and feel free to [get in touch](/community/help-and-support/) if you have any questions!
 
 [reference-client#createdelegation]: ../../api/w3up-client/classes/client.Client.md#createdelegation
 

--- a/src/pages/concepts/ucans-and-storacha.md
+++ b/src/pages/concepts/ucans-and-storacha.md
@@ -113,4 +113,4 @@ When the `frontend` function is called in the user's environment:
 - The client is set up with a UCAN delegating upload capabilities to the Agent
 - It's now ready to upload!
 
-However, there's other interesting possibilities - for instance, you could create an app where your users make Spaces and delegate permission to your app to read their uploads. Read the [Architecture options](/docs/concepts/architecture-options/) section to explore more.
+However, there's other interesting possibilities - for instance, you could create an app where your users make Spaces and delegate permission to your app to read their uploads. Read the [Architecture options](/concepts/architecture-options/) section to explore more.

--- a/src/pages/concepts/upload-vs-store.md
+++ b/src/pages/concepts/upload-vs-store.md
@@ -77,4 +77,4 @@ However, if you are a power user interacting with shard CIDs as well (like in th
 
 ## When should I care about Piece CIDs?
 
-Piece CIDs are how you can reference your data when it is stored in Filecoin Storage Providers. You can think of Piece CIDs as another way to reference a shard - they are in fact calculated from shard data. Piece CIDs are used in [PoDSI (Proof of Data Segment Inclusion)](/docs/concepts/podsi/) - a proof that a piece is included in a larger piece, which allows users and third parties to prove their data is stored with a Filecoin Storage Provider.
+Piece CIDs are how you can reference your data when it is stored in Filecoin Storage Providers. You can think of Piece CIDs as another way to reference a shard - they are in fact calculated from shard data. Piece CIDs are used in [PoDSI (Proof of Data Segment Inclusion)](/concepts/podsi/) - a proof that a piece is included in a larger piece, which allows users and third parties to prove their data is stored with a Filecoin Storage Provider.

--- a/src/pages/faq.md
+++ b/src/pages/faq.md
@@ -23,7 +23,7 @@ However, once a file is uploaded to Storacha, there cannot be a guarantee that a
 
 ## Are there client libraries other than Javascript?
 
-Yes! There is a [client in Go](/docs/go-w3up). However, it is heavily under development at the time of writing and not yet fully featured. Alternatively, you can use the CLI for many programmatic use cases.
+Yes! There is a [client in Go](/go-w3up). However, it is heavily under development at the time of writing and not yet fully featured. Alternatively, you can use the CLI for many programmatic use cases.
 
 ## How can I edit a file or add files to a folder?
 

--- a/src/pages/go-w3up.mdx
+++ b/src/pages/go-w3up.mdx
@@ -4,7 +4,7 @@ import { Steps } from 'nextra/components'
 # `go-w3up`
 
 <Callout type="warning">
-  The Go client is under heavily development and is not as fully featured as the [JS client](/docs/w3up-client).
+  The Go client is under heavily development and is not as fully featured as the [JS client](/w3up-client).
 </Callout>
 
 You can easily integrate Storacha into your Go apps using `go-w3up`, our Go client for the w3up platform.

--- a/src/pages/how-to/ci.mdx
+++ b/src/pages/how-to/ci.mdx
@@ -58,13 +58,13 @@ The rest of this document explains the process in more detail.
 
 ## Create a space
 
-On your local machine with [w3cli][] installed and logged in (see: https://storacha.network/docs/quickstart/) run
+On your local machine with [w3cli][] installed and logged in (see: /quickstart/) run
 
 ```shell
 $ w3 space create
 ```
 
-and follow the instructions. (See: https://storacha.network/docs/how-to/create-space/#using-the-cli if you get stuck.)
+and follow the instructions. (See: /how-to/create-space/#using-the-cli if you get stuck.)
 
 If you want to use an existing space, make sure it is set as your current space using `w3 space ls` and `w3 space use`
 

--- a/src/pages/how-to/create-space.mdx
+++ b/src/pages/how-to/create-space.mdx
@@ -2,9 +2,9 @@ import { Callout } from 'nextra/components'
 
 # How to create a space
 
-In this how-to guide, you'll learn how to create a Storacha Space to organize stored data. For an overview of the various ways Storacha can be integrated with your application, check out [Architecture Options](/docs/concepts-architecture-options/).
+In this how-to guide, you'll learn how to create a Storacha Space to organize stored data. For an overview of the various ways Storacha can be integrated with your application, check out [Architecture Options](/concepts-architecture-options/).
 
-A Space acts as a namespace for your uploads. It is created locally, offline, and associated with a cryptographic key pair (identified by the [`did:key`](https://w3c-ccg.github.io/did-method-key/) of the public key). You can register this Space with your [storacha account](/docs/how-to/create-account/) to take responsibility for the uploads in the space. Once you do this, you don't need to worry about keeping track of the Space's private key, because your Storacha account has been authorized to use the Space.
+A Space acts as a namespace for your uploads. It is created locally, offline, and associated with a cryptographic key pair (identified by the [`did:key`](https://w3c-ccg.github.io/did-method-key/) of the public key). You can register this Space with your [storacha account](/how-to/create-account/) to take responsibility for the uploads in the space. Once you do this, you don't need to worry about keeping track of the Space's private key, because your Storacha account has been authorized to use the Space.
 
 ## Using the CLI
 
@@ -26,7 +26,7 @@ The easiest way to create and register a Space is by using the CLI.
 
 Separately, you can visit [console.storacha](https://console.storacha.network/), sign up with your email and select a plan, and create a space using the UI, but we recommend that developers get familiar with the CLI since it's a powerful tool for many things you might want to do.
 
-The Space you create can be used to [upload](/docs/how-to/upload/) data using the CLI, the w3up client, or when you log into the web console.
+The Space you create can be used to [upload](/how-to/upload/) data using the CLI, the w3up client, or when you log into the web console.
 
 ## Using the JS client
 
@@ -34,5 +34,5 @@ The Space you create can be used to [upload](/docs/how-to/upload/) data using th
 2. Call `client.createSpace('Documents')` and wait for the promise to resolve.
 
 <Callout>
-  The space must be provisioned by an account before it can be used for uploads. See [our guide](/docs/w3up-client/#create-and-provision-a-space) for details.
+  The space must be provisioned by an account before it can be used for uploads. See [our guide](/w3up-client/#create-and-provision-a-space) for details.
 </Callout>

--- a/src/pages/how-to/filecoin-info.mdx
+++ b/src/pages/how-to/filecoin-info.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra/components'
 
 # Get Filecoin information for a Piece
 
-To retrieve a [Data Aggregation Proof](/docs/concepts/podsi#data-aggregation-proof) (including [PoDSI](/docs/concepts/podsi)) you can issue a `filecoin/info` invocation to the Storacha service.
+To retrieve a [Data Aggregation Proof](/concepts/podsi#data-aggregation-proof) (including [PoDSI](/concepts/podsi)) you can issue a `filecoin/info` invocation to the Storacha service.
 
 ## Using the JS client
 
@@ -12,7 +12,7 @@ Piece CIDs are calculated by the client before data is uploaded and are made ava
   If you did not store the piece CID when your content was uploaded you can query [content claims](https://www.npmjs.com/package/@web3-storage/content-claims) for an equivalency claim.
 </Callout>
 
-Later, you can use the piece CID to retrieve a [Data Aggregation Proof](/docs/concepts/podsi#data-aggregation-proof):
+Later, you can use the piece CID to retrieve a [Data Aggregation Proof](/concepts/podsi#data-aggregation-proof):
 
 ```js
 const result = await client.capability.filecoin.info(piece)
@@ -55,7 +55,7 @@ Piece CIDs are calculated by the client before data is uploaded and will be prin
   If you did not store the piece CID when your content was uploaded you can query [content claims](https://www.npmjs.com/package/@web3-storage/content-claims) for an equivalency claim.
 </Callout>
 
-Later, you can use the piece CID to print out [Data Aggregation Proof](/docs/concepts/podsi#data-aggregation-proof) information:
+Later, you can use the piece CID to print out [Data Aggregation Proof](/concepts/podsi#data-aggregation-proof) information:
 
 ```sh
 $ w3 can filecoin info bafkzcibe52kq2dtip2bmrrw5qhphsa35onsxxvkuxl33dnotq2allfpz7tdxlhc5di

--- a/src/pages/how-to/list.mdx
+++ b/src/pages/how-to/list.mdx
@@ -11,7 +11,7 @@ In this how-to guide, you'll learn about the different ways that you can list th
 
 You can also access a listing of your uploads from your code using the Storacha client. In the example below, this guide walks through how to use the JavaScript client library to fetch a complete listing of all the data you've uploaded using Storacha.
 
-For instructions on how to set up your client instance or CLI, check out the [Upload](/docs/how-to/upload/) section.
+For instructions on how to set up your client instance or CLI, check out the [Upload](/how-to/upload/) section.
 
 Today, like other developer object storage solutions, there is no sorting or querying by timestamp to keep things scalable.
 
@@ -20,7 +20,7 @@ Today, like other developer object storage solutions, there is no sorting or que
 
 In the client the listing is paginated. The result contains a `cursor` that can be used to continue listing uploads. Pass the `cursor` in the result as an _option_ to the next call to receive the next page of results. The `size` option allows you to change the number of items that are returned per page.
 
-In the CLI, you can use the `--shards` option to print for each upload the list of shards (CAR CIDs) that the uploaded data is contained within. You can learn about the relationship between uploads and shards in the [Upload vs. Store](/docs/concepts/upload-vs-store/) section.
+In the CLI, you can use the `--shards` option to print for each upload the list of shards (CAR CIDs) that the uploaded data is contained within. You can learn about the relationship between uploads and shards in the [Upload vs. Store](/concepts/upload-vs-store/) section.
 
 <Callout type="info">
   The `w3 ls` command automatically pages through the listing and prints the results.
@@ -39,7 +39,7 @@ A list of shards for a given upload can be retrieved like this:
 
 - Client: `client.capability.upload.get(contentCID)`
 
-You can learn about the relationship between uploads and shards in the [Upload vs. Store](/docs/concepts/upload-vs-store/) section.
+You can learn about the relationship between uploads and shards in the [Upload vs. Store](/concepts/upload-vs-store/) section.
 
 ## Using the console web UI
 

--- a/src/pages/how-to/retrieve.mdx
+++ b/src/pages/how-to/retrieve.mdx
@@ -6,10 +6,10 @@ In this how-to guide, you'll learn several methods for retrieving data from Stor
 
 All data stored using Storacha is made available for retrieval via [IPFS](https://ipfs.io/), the InterPlanetary File System. IPFS is a distributed, peer-to-peer network for storing and sharing content-addressed data. This guide shows you several ways to retrieve your data from IPFS:
 
-- In your browser using an [HTTP gateway](/docs/how-to/retrieve/#using-an-ipfs-http-gateway).
+- In your browser using an [HTTP gateway](/how-to/retrieve/#using-an-ipfs-http-gateway).
 - Using the [Saturn dCDN](https://saturn.tech/).
-- In your terminal using the [IPFS command-line tools](/docs/how-to/retrieve/#using-the-ipfs-command-line).
-- In your terminal using [curl or Powershell](/docs/how-to/retrieve/#using-curl-or-powershell).
+- In your terminal using the [IPFS command-line tools](/how-to/retrieve/#using-the-ipfs-command-line).
+- In your terminal using [curl or Powershell](/how-to/retrieve/#using-curl-or-powershell).
 
 When retrieving any data, you'll be using the content CID of the upload (prefixed by `bafy…`).
 
@@ -96,4 +96,4 @@ Replace `<YOUR_CID>`, `<FILE_NAME>`, and `<OUTPUT_FILE>` with their respective v
 
 ## Next steps
 
-Next, you'll learn about how to [list](/docs/how-to/list/) uploaded content.
+Next, you'll learn about how to [list](/how-to/list/) uploaded content.

--- a/src/pages/how-to/upload.mdx
+++ b/src/pages/how-to/upload.mdx
@@ -363,4 +363,4 @@ function makeFileObjects () {
 
 ## Next steps
 
-Learn more about how to fetch your data using the CID in the next section, [retrieve](/docs/how-to/retrieve/).
+Learn more about how to fetch your data using the CID in the next section, [retrieve](/how-to/retrieve/).

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -20,9 +20,9 @@ When it comes down to building your next application, service, or website, Stora
 
 Whether you’re building with **JavaScript**, **TypeScript**  or **Go**, we've got you covered:
 
-- **JavaScript/TypeScript:** Check out our [guide to using w3up-client](/docs/w3cli).
-- **Command Line Interface:** Dive into our [CLI adventure](/docs/w3up-client) to master the w3up.
-- **Go Client:** Explore our [Go client](/docs/go-w3up) for robust backend integrations.
+- **JavaScript/TypeScript:** Check out our [guide to using w3up-client](/w3cli).
+- **Command Line Interface:** Dive into our [CLI adventure](/w3up-client) to master the w3up.
+- **Go Client:** Explore our [Go client](/go-w3up) for robust backend integrations.
 
 Feeling terminal? Jump in to our **command line adventure** to learn you the w3up for much win!
 
@@ -51,7 +51,7 @@ Got questions or need a bit of help? Don’t hesitate to [contact our support te
 Thanks for joining us on this adventure. Let’s make storage history together with Storacha Network – where your data stays hot and happening!
 
 <Cards>
-  <Card icon='💾 ' title="CLI" href="/docs/w3cli" />
-  <Card icon='✨ ' title="JS Client" href="/docs/w3up-client" />
-  <Card icon='🐹 ' title="Go Client" href="/docs/go-w3up" />
+  <Card icon='💾 ' title="CLI" href="/w3cli" />
+  <Card icon='✨ ' title="JS Client" href="/w3up-client" />
+  <Card icon='🐹 ' title="Go Client" href="/go-w3up" />
 </Cards>

--- a/src/pages/privacy-policy.md
+++ b/src/pages/privacy-policy.md
@@ -4,12 +4,12 @@
 
 This Privacy Policy governs all use of the Storacha website (“Storacha” or the “Website”), the w3link/w3s.link gateway (“Gateway”) and all content, services and products available at or through the Website or Gateway (collectively, “Services”).
 
-The Services are offered subject to your acceptance without modification of all the terms and conditions herein, and all other other operating rules, policies (including, without limitation, our [Terms of Service](/docs/terms/) and procedures that may be updated from time to time.  By accessing or using any part of our Services you agree to be bound by the terms and conditions of the Privacy Policy.  If you do not agree to all of the terms and conditions of this Privacy Policy, then you may not access our Services.
+The Services are offered subject to your acceptance without modification of all the terms and conditions herein, and all other other operating rules, policies (including, without limitation, our [Terms of Service](/terms/) and procedures that may be updated from time to time.  By accessing or using any part of our Services you agree to be bound by the terms and conditions of the Privacy Policy.  If you do not agree to all of the terms and conditions of this Privacy Policy, then you may not access our Services.
 
 We keep your personal information personal and private. We will not sell or rent your personal information to anyone. We will not share or otherwise disclose your personal information except as necessary to provide our Services or as otherwise described in this Privacy Policy without first providing you with notice and the opportunity to consent.
 By accessing or using any part of our Services, including the Websites, you agree to be bound by the terms and conditions of the Privacy Policy.  If you do not agree to all of the terms and conditions of this Privacy Policy, then you may not access our Services.
 
-The Services are offered subject to your acceptance without modification of all the terms and conditions herein, and all other other operating rules, policies (including, without limitation, our [Terms of Service](/docs/terms/) and procedures that may be updated from time to time by Nitro Data LLC (collectively, the “Agreement”).
+The Services are offered subject to your acceptance without modification of all the terms and conditions herein, and all other other operating rules, policies (including, without limitation, our [Terms of Service](/terms/) and procedures that may be updated from time to time by Nitro Data LLC (collectively, the “Agreement”).
 
 ### Who Do We Collect Information From?
 

--- a/src/pages/quickstart.md
+++ b/src/pages/quickstart.md
@@ -89,8 +89,8 @@ __  _  __  ____  \_ |__  \_____  \      _______/  |_   ____  _______ _____      
 
 Congratulations! You've just covered the basics of Storacha. To learn more, take a look at these useful resources:
 
-- For a deep dive into storing files, including using the Javascript client to do so, visit the [Upload how-to guide](/docs/how-to/upload).
-- Read more about the power of [UCANs and IPFS](/docs/concepts/ucans-and-storacha), and learn about the various options to integrate Storacha with your application.
+- For a deep dive into storing files, including using the Javascript client to do so, visit the [Upload how-to guide](/how-to/upload).
+- Read more about the power of [UCANs and IPFS](/concepts/ucans-and-storacha), and learn about the various options to integrate Storacha with your application.
 
 <!-- - Try out our image gallery example to see how easy it is to take advantage of these decentralized protocols using Storacha.
 - Visit the reference API section for more details on what else you can do with the Storacha client and how to integrate it into your own projects. -->

--- a/src/pages/service-level-agreement.md
+++ b/src/pages/service-level-agreement.md
@@ -32,9 +32,9 @@ Nitro Data LLC ("Company") commits to provide a level of service for Storacha Cu
 
 2.9 "Services" means, collectively, the Upload Service and the Read Service.
 
-2.10 “Upload Service” refers to uploads through the website, client, and CLI for supported file types and sizes as defined by the docs available at https://storacha/docs/.
+2.10 “Upload Service” refers to uploads through the website, client, and CLI for supported file types and sizes as defined by the docs available at https://docs.storacha.network/.
 
-2.11 “Read Service” refers to reading successfully uploaded data, using its CID, over [w3link](https://storacha/products/w3link/) or via Bitswap using IPFS nodes peered with Storacha nodes.
+2.11 “Read Service” refers to reading successfully uploaded data, using its CID, over https://w3s.link or via Bitswap using IPFS nodes peered with Storacha nodes.
 
 2.12 "Service Discount" is the percentage of the monthly service fees for the Services deducted from Customer’s next monthly bill for a validated Claim.
 


### PR DESCRIPTION
When moving from `web3.storage/docs` to `docs.storacha.network` we made many 404s.