### PR TITLE
refactor(w3up-client): move auth'd gateways to a config note

### DIFF
--- a/src/pages/referral-terms.md
+++ b/src/pages/referral-terms.md
@@ -1,39 +1,50 @@
 # User Referral Program Terms and Conditions
 
 ## 1. Program Overview
+
 1.1. This Referral Program ("Program") allows individuals ("Referrers") to earn rewards (“Rewards”) by referring new users ("Referred Users") to Storacha.
 
-1.2. This Program also allows Referred Users to participate in a free trial (“Free Trial”) on Storacha. 
+1.2. This Program also allows Referred Users to participate in a free trial (“Free Trial”) on Storacha.
 
-1.3. By participating in the Program, both Referrers and Referred Users agree to be bound by these Terms and Conditions (“Terms”) and the [Terms of Service](https://docs.storacha.network/terms/). 
+1.3. By participating in the Program, both Referrers and Referred Users agree to be bound by these Terms and Conditions (“Terms”) and the [Terms of Service](https://docs.storacha.network/terms/).
 
 ## 2. Participation Eligibility
+
 ### 2.1. Referrers:
+
 Do not have to be current users to refer new users, but must sign up to Storacha to receive their referral Rewards
 Must comply with all platform [Terms of Service](https://docs.storacha.network/terms/)
 
 ### 2.2. Referred Users:
+
 - Must be new to the platform
 - Cannot have previously held an account with Storacha
 - Must comply with all platform [Terms of Service](https://docs.storacha.network/terms/)
 
 ## 3. Reward Eligibility & Structure
+
 ### 3.1 Types of Rewards:
+
 Two types of Rewards can be earned by participating the Program:
-- Storage credits (“Credits”) that can be applied to Lite/Medium or Business/Extra Spicy subscriptions 
+
+- Storage credits (“Credits”) that can be applied to Lite/Medium or Business/Extra Spicy subscriptions
 - Loyalty points (“Racha Points”)
 
 ### 3.2 Referrer Reward Eligibility:
+
 A Referrer is eligible to receive Rewards if a successful referral (“Successful Referral”) which requires that the following conditions are met:
+
 - Their Referred User signs up to Storacha (Lite/Medium tier or Business/Extra Spicy tier) using the referral link or code they provided AND
 - If their Referred User signs up for Lite/Medium, this Referred User has paid for at least two months of storage beyond their Free Trial (“Successful Lite Referral”) OR
 - If their Referred User signed up for Business/Extra Spicy, this Referred User has paid for at least one month of storage beyond their free trial (“Successful Business Referral”)
 
 ### 3.3 Referrer Rewards from a Successful Referral:
+
 - For a Successful Lite Referral, the Referrer will receive 20 Credits and 20 Racha Points, subject to the restrictions outlined in Section 3.4
 - For a Successful Business Referral, the Referrer will receive 100 Credits and 100 Racha Points, subject to the restrictions outlined in Section 3.4
 
 ### 3.4 Referrer Reward restrictions:
+
 - Referrer will only receive Credits if they have a Lite/Medium or Business/Extra Spicy plan at the time or referral
 - Total referral reward limit: 460 Credits
   - Up to 160 Credits for Lite/Medium tier referrals
@@ -42,19 +53,24 @@ A Referrer is eligible to receive Rewards if a successful referral (“Successfu
 - All Credits expire 12 months from date of issue
 
 ### 3.5 Free Trial and Rewards for Referred Users
+
 Referred Users who sign up through a referral link/code qualify for the following free trial periods:
+
 - Lite/Medium tier: 2-month free trial from signup date
 - Business/Extra Spicy tier: 1-month free trial from signup date
 
 Eligibility for Racha Points:
+
 - Lite/Medium subscribers: 20 Racha Points after paying for 2 months after the end of their Free Trial
 - Business/Extra Spicy subscribers: 100 Racha Points after paying for 1 month after the end of their Free Trial
 
 ### 3.6 Referred User Reward restrictions:
+
 - If a Referred User cancels their subscription during their Free Trial, they will forfeit the remaining time on the Free Trial.
 - A Referred User cannot change their free subscription choice after it has been confirmed.
 
 ## 4. No Cash Value of Rewards
+
 - Credits and Racha Points have no monetary value and cannot be exchanged for cash
 - Rewards are non-transferable, non-assignable, and cannot be sold or traded
 - Credits and Racha Points:
@@ -67,6 +83,7 @@ Eligibility for Racha Points:
 ## 5. Participant Relationship Status
 
 ### 5.1. Independent Participation
+
 - Participation in the Referral Program is voluntary and independent
 - Neither Program participation nor reward receipt creates or implies any:
   - Employment relationship
@@ -78,6 +95,7 @@ Eligibility for Racha Points:
   - Legal representation authority
 
 ### 5.2. Prohibited Activities
+
 - Participants must not:
   - Represent themselves as Storacha, Inc. (“Company”) employees or official representatives
   - Make promises or commitments on behalf of the Company
@@ -86,6 +104,7 @@ Eligibility for Racha Points:
   - Enter into agreements on the Company's behalf
 
 ### 5.3. Scope of Relationship
+
 - Participants act solely as independent promoters
 - The relationship is limited to Program participation under these terms
 - Participants have no authority to bind or represent the Company
@@ -93,7 +112,9 @@ Eligibility for Racha Points:
 - All Program activities are conducted at participant's own expense and risk
 
 ## 6. Prohibited Activities
+
 The following activities are strictly prohibited:
+
 - Self-referrals or creating multiple accounts
 - Using automated systems to generate referrals
 - Spamming or unauthorized advertising
@@ -104,7 +125,9 @@ The following activities are strictly prohibited:
 - Any prohibited activity listed in the [Terms of Service](https://docs.storacha.network/terms/)
 
 ## 7. Company Rights and Remedies
+
 ### 7.1. The Company reserves the right to:
+
 - Monitor all Program activity for compliance
 - Investigate suspicious or potentially fraudulent activity
 - Delay or withhold Rewards pending investigation
@@ -114,6 +137,7 @@ The following activities are strictly prohibited:
 - Interpret and apply these terms at its sole discretion
 
 ### 7.2. In cases of suspected abuse or violation, the Company may:
+
 - Immediately suspend all pending Rewards
 - Reverse previously awarded credits
 - Terminate user accounts
@@ -121,7 +145,9 @@ The following activities are strictly prohibited:
 - Take legal action if necessary
 
 ## 8. Reward Withholding and Clawback
+
 The Company may withhold or rescind Rewards if:
+
 - Either party violates these terms or the terms outlined in [Terms of Service](https://docs.storacha.network/terms/)
 - Suspicious patterns of activity are detected
 - Referred User fails to meet qualifying criteria
@@ -131,7 +157,9 @@ The Company may withhold or rescind Rewards if:
 - Referral activity violates any platform policies
 
 ## 9. Program Modifications
+
 The Company may at any time:
+
 - Change reward amounts or structure
 - Modify eligibility requirements
 - Adjust qualifying criteria
@@ -140,7 +168,9 @@ The Company may at any time:
 - Terminate the Program
 
 ## 10. Limitation of Liability
+
 The Company is not responsible for:
+
 - Technical failures affecting referral tracking
 - Lost or delayed Rewards due to system errors
 - Unauthorized access to referral codes
@@ -148,18 +178,24 @@ The Company is not responsible for:
 - Tax implications of reward payments
 
 ## 11. No Representations, Warranties, or Guarantees
+
 ### 11.1 Program Participation
+
 - Participation in the Program is voluntary and does not create any legal right, claim, or entitlement to Rewards
 - No guarantee is made regarding the continuous availability or operation of the Program
 - The Company makes no representations about potential earnings or benefits from Program participation
+
 ### 11.2 Technical Operation
+
 - The Program is provided "as is" and "as available"
 - No warranty is made regarding:
 - Accuracy of referral tracking
 - Uninterrupted Program access
 - Error-free operation
 - Availability of specific Rewards
+
 ### 11.3 Legal Rights
+
 - Participants expressly acknowledge that Rewards are discretionary benefits, not legal entitlements
 - No legal partnership, agency, or similar relationship is created through Program participation
 - Participants waive any right to claim damages related to:
@@ -167,7 +203,9 @@ The Company is not responsible for:
   - Technical limitations or failures
   - Reward distribution timing
   - Verification processes
+
 ### 11.4 Discretionary Authority
+
 - Notwithstanding any other provisions in these terms, the Company maintains absolute and sole discretion to withhold, delay, or rescind any reward for any reason whatsoever, including but not limited to:
   - Technical errors or malfunctions
   - Clerical or administrative errors
@@ -180,6 +218,7 @@ The Company is not responsible for:
 - No participant shall have any vested right or entitlement to receive Rewards, regardless of whether all apparent qualifying conditions have been met
 
 ## 12. Local Law Compliance and Tax Obligations
+
 - The Program may not be available in all jurisdictions and is void where prohibited by law
 - Participants are solely responsible for determining their eligibility and ensuring compliance with all applicable local laws, regulations, and tax obligations
 - The Company may limit or restrict Program participation based on jurisdictional requirements
@@ -187,18 +226,21 @@ The Company is not responsible for:
 - The Company may require tax documentation before distributing Rewards and may report reward values to tax authorities as required by law
 
 ## 13. Finality of Decisions
+
 - All Company decisions regarding the Program, including eligibility, Rewards, investigations, and disputes, are final and binding
 - The Company maintains sole discretion in all Program matters
 - Participants agree to accept all Company decisions without right of appeal
 
 ## 14. No Waiver
+
 - The Company’s failure, delay, or partial exercise of any right, power, or remedy under these Terms or applicable law shall not operate as a waiver of that right, power, or remedy, nor shall it preclude any other or further exercise thereof
 - Any waiver must be expressly made in a written instrument signed by an authorized representative of the Company
 - A waiver of any provision of these Terms on one occasion does not constitute a waiver of the same or any other provision on any future occasion
 
 ## 15. Contact
+
 Questions about the Program or these terms should be directed to our support team at support@storacha.network
 
 ## 16. Acceptance
-Participation in the Program constitutes acceptance of these Terms and Conditions and the [Terms of Service](https://docs.storacha.network/terms/).
 
+Participation in the Program constitutes acceptance of these Terms and Conditions and the [Terms of Service](https://docs.storacha.network/terms/).

--- a/src/pages/w3cli.mdx
+++ b/src/pages/w3cli.mdx
@@ -59,7 +59,6 @@ The DID for the new space will be printed to the console. It should look somethi
 did:key:z6MkixXechJLc3TWibQj9RN6AiFx8VoMY9HNB3Y97WcwK3fm
 ```
 
-
 You can now run `w3 space ls` to show a list of your spaces:
 
 ```bash

--- a/src/pages/w3up-client.md
+++ b/src/pages/w3up-client.md
@@ -51,41 +51,10 @@ If your account doesn't have a payment plan yet, you'll be prompted to select on
 await account.plan.wait();
 ```
 
-Spaces can be created using the `createSpace` client method. When creating a space, you can specify which Gateways are authorized to serve the content you upload. To achieve this, you must first establish a connection with the desired Gateway. This connection enables the client to publish the necessary delegations that grant the Gateway permission to serve your content. 
-
-If no Gateways are specified (`authorizeGatewayServices`), or if the `skipGatewayAuthorization` flag is not set, the client will automatically grant access to the [Storacha Gateway](https://github.com/storacha/freeway) to serve the content you upload to your space.
-
-To configure other Gateways to serve the content you upload to your new space, follow these steps:
+Spaces can be created using the `createSpace` client method.
 
 ```js
-import * as UcantoClient from '@ucanto/client'
-import { HTTP } from '@ucanto/transport'
-import * as CAR from '@ucanto/transport/car'
-
-// Connects to Storacha Freeway Gateway
-const storachaGateway = UcantoClient.connect({
-    id: id,
-    codec: CAR.outbound,
-    channel: HTTP.open({ url: new URL('https://freeway.dag.haus') }),
-});
-```
-
-Once connected to the Gateway, you can create a space:
-
-```js
-const space = await client.createSpace("my-awesome-space", { 
-  account,
-  authorizeGatewayServices: [storachaGateway],
-});
-```
-
-If you want to ensure that no Gateway is authorized to serve the content of your space, you can use the `skipGatewayAuthorization` flag:
-
-```js
-const space = await client.createSpace("my-awesome-space", { 
-  account,
-  skipGatewayAuthorization: true,
-});
+const space = await client.createSpace("my-awesome-space", { account });
 ```
 
 Alternatively, you can use the `w3cli` command [`w3 space create`](https://github.com/storacha/w3cli#w3-space-create-name) for a streamlined approach.
@@ -108,6 +77,47 @@ Alternatively, you can use the `w3cli` command [`w3 space create`](https://githu
 
     ```js
     await client.setCurrentSpace(space.did());
+    ```
+
+5.  **Authorized Gateways**
+
+    When creating a space, you can specify which Gateways are authorized to serve the content you upload. By default, if no other flags are set the client will automatically grant access to the [Storacha Gateway](https://github.com/storacha/freeway) to serve the content you upload to your space.
+
+    However, you can authorize other Storacha compliant gateways to serve content instead.
+
+    To achieve this, you must first establish a connection with the desired Gateway. This connection enables the client to publish the necessary delegations that grant the Gateway permission to serve your content.
+
+    To configure other Gateways to serve the content you upload to your new space, follow these steps:
+
+    ```js
+    import * as UcantoClient from '@ucanto/client'
+    import { HTTP } from '@ucanto/transport'
+    import * as CAR from '@ucanto/transport/car'
+
+    // Connects to Storacha Freeway Gateway
+    const storachaGateway = UcantoClient.connect({
+        id: id,
+        codec: CAR.outbound,
+        channel: HTTP.open({ url: new URL('https://freeway.dag.haus') }),
+    });
+    ```
+
+    Once connected to the Gateway, you can create a space and authorize serving content from that gateway:
+
+    ```js
+    const space = await client.createSpace("my-awesome-space", { 
+      account,
+      authorizeGatewayServices: [storachaGateway],
+    });
+    ```
+
+    If you want to ensure that no Gateway is authorized to serve the content of your space, you can use the `skipGatewayAuthorization` flag:
+
+    ```js
+    const space = await client.createSpace("my-awesome-space", { 
+      account,
+      skipGatewayAuthorization: true,
+    });
     ```
 
 ## Upload files


### PR DESCRIPTION
# Goals

New information on specifying gateways is great, but it's very much an "expert" setting, and having the documentation directly in the path for creating a space makes it really confusing.

# Implementation

This PR just moves Authorized Gateway into the notes, while leaving the happy path the simple default that delegates to the Storacha gateway.

# For Discussion

There's an additional layer of confusion here we should really figure out how to tackle. We're using Authorized Gateway here to refer to a service that is authorized to serve content from storcha storage nodes, over potentially arbitrary protocols. However, the word "Gateway" in IPFS parlance, i.e. the majority of our users, means simply a service that serves IPFS content over HTTP. In particular, I worry that people may read this section and believe this means they have to explicitly authorize the ipfs.io gateway. In fact, they don't, and what they need to authorize (and which will be authorized by default) is Hoverboard, i.e. our bitswap node.

Because this is down in the notes now, I'm not as concerned but especially when we actually role out private spaces, we should consider our API and language carefully to help users understand what we're talking about.
