### PR TITLE
fix: typo in go-w3up.mdx

### DIFF
--- a/src/pages/go-w3up.mdx
+++ b/src/pages/go-w3up.mdx
@@ -4,7 +4,7 @@ import { Steps } from 'nextra/components'
 # `go-w3up`
 
 <Callout type="warning">
-  The Go client is under heavily development and is not as fully featured as the [JS client](/w3up-client).
+  The Go client is under heavy development and is not as fully featured as the [JS client](/w3up-client).
 </Callout>
 
 You can easily integrate Storacha into your Go apps using `go-w3up`, our Go client for the w3up platform.


### PR DESCRIPTION
update with small typo at the [Go Client](https://docs.storacha.network/go-w3up/) page.
![image](https://github.com/user-attachments/assets/bbcdaf57-af41-43ba-b21e-180e50146c82)
