### PR TITLE
fix: update typo for client Agent object

### DIFF
--- a/src/pages/concepts/architecture-options.mdx
+++ b/src/pages/concepts/architecture-options.mdx
@@ -1,4 +1,4 @@
-import { Callout } from "nextra/components";
+import { Callout } from 'nextra/components'
 
 # Possible architectures using Storacha to upload
 
@@ -25,11 +25,7 @@ w3up-client in backend-\>\>storacha w3up service: Upload data
 You'll need a registered Space, and your client in the backend to have a delegation to use the Space.
 
 <Callout>
-  **Recommended**: It's easiest to create and register your Space using
-  [w3cli](https://github.com/storacha/w3cli), then create an identity for your
-  server and delegate it the ability to upload to your Space. The [bring your
-  own delegations](/how-to/upload/#bring-your-own-delegations) section shows how
-  to generate an identity, create a delegation and then use it on the server.
+  **Recommended**: It's easiest to create and register your Space using [w3cli](https://github.com/storacha/w3cli), then create an identity for your server and delegate it the ability to upload to your Space. The [bring your own delegations](/how-to/upload/#bring-your-own-delegations) section shows how to generate an identity, create a delegation and then use it on the server.
 </Callout>
 
 After this, once your user uploads data to your backend, you can run any of the upload methods.
@@ -57,11 +53,7 @@ Typically `w3up-client` will be running in your end-user's client code, as well 
 You'll need a registered Space, and your client in the backend to have a delegation to use the Space.
 
 <Callout>
-  **Recommended**: It's easiest to create and register your Space using
-  [w3cli](https://github.com/storacha/w3cli), then create an identity for your
-  server and delegate it the ability to upload to your Space. The [bring your
-  own delegations](/how-to/upload/#bring-your-own-delegations) section shows how
-  to generate an identity, create a delegation and then use it on the server.
+  **Recommended**: It's easiest to create and register your Space using [w3cli](https://github.com/storacha/w3cli), then create an identity for your server and delegate it the ability to upload to your Space. The [bring your own delegations](/how-to/upload/#bring-your-own-delegations) section shows how to generate an identity, create a delegation and then use it on the server.
 </Callout>
 
 Your backend code can then re-delegate it's capabilities to your users. Your user does not need a registered Space - just an Agent with a delegation from your Space.
@@ -77,10 +69,7 @@ The client the user is using does not need to call `client.login(email)`, as it 
 When your user receives the delegation, they can deserialize it using [`Delegation.extract()`](https://github.com/storacha/ucanto/blob/c8999a59852b61549d163532a83bac62290b629d/packages/core/src/delegation.js#L399) and pass it in using `client.addSpace()`, and from there they can run any of the upload methods.
 
 <Callout type="info">
-  This does not provide visibility over which users are uploading what; to track
-  this, you'll need to share that information separately (e.g., once they've run
-  upload and get back a content CID, you can have them send that CID to you for
-  tracking).
+  This does not provide visibility over which users are uploading what; to track this, you'll need to share that information separately (e.g., once they've run upload and get back a content CID, you can have them send that CID to you for tracking).
 </Callout>
 
 A code example that does this can be found below:
@@ -88,68 +77,59 @@ A code example that does this can be found below:
 **Backend**
 
 ```js
-import * as Client from "@web3-storage/w3up-client";
-import { StoreMemory } from "@web3-storage/w3up-client/stores/memory";
-import * as Proof from "@web3-storage/w3up-client/proof";
-import { Signer } from "@web3-storage/w3up-client/principal/ed25519";
-import * as DID from "@ipld/dag-ucan/did";
+import * as Client from '@web3-storage/w3up-client'
+import { StoreMemory } from '@web3-storage/w3up-client/stores/memory'
+import * as Proof from '@web3-storage/w3up-client/proof'
+import { Signer } from '@web3-storage/w3up-client/principal/ed25519'
+import * as DID from '@ipld/dag-ucan/did'
 
 async function backend(did) {
   // Load client with specific private key
-  const principal = Signer.parse(process.env.KEY);
-  const store = new StoreMemory();
-  const client = await Client.create({ principal, store });
+  const principal = Signer.parse(process.env.KEY)
+  const store = new StoreMemory()
+  const client = await Client.create({ principal, store })
 
   // Add proof that this agent has been delegated capabilities on the space
-  const proof = await Proof.parse(process.env.PROOF);
-  const space = await client.addSpace(proof);
-  await client.setCurrentSpace(space.did());
+  const proof = await Proof.parse(process.env.PROOF)
+  const space = await client.addSpace(proof)
+  await client.setCurrentSpace(space.did())
 
   // Create a delegation for a specific DID
-  const audience = DID.parse(did);
-  const abilities = [
-    "space/blob/add",
-    "space/index/add",
-    "filecoin/offer",
-    "upload/add",
-  ];
-  const expiration = Math.floor(Date.now() / 1000) + 60 * 60 * 24; // 24 hours from now
-  const delegation = await client.createDelegation(audience, abilities, {
-    expiration,
-  });
+  const audience = DID.parse(did)
+  const abilities = ['space/blob/add', 'space/index/add', 'filecoin/offer', 'upload/add']
+  const expiration = Math.floor(Date.now() / 1000) + (60 * 60 * 24) // 24 hours from now
+  const delegation = await client.createDelegation(audience, abilities, { expiration })
 
   // Serialize the delegation and send it to the client
-  const archive = await delegation.archive();
-  return archive.ok;
+  const archive = await delegation.archive()
+  return archive.ok
 }
 ```
 
 **Frontend**
 
 ```js
-import * as Delegation from "@web3-storage/w3up-client/delegation";
-import * as Client from "@web3-storage/w3up-client";
+import * as Delegation from '@web3-storage/w3up-client/delegation'
+import * as Client from '@web3-storage/w3up-client'
 
 async function frontend() {
   // Create a new client
-  const client = await Client.create();
+  const client = await Client.create()
 
   // Fetch the delegation from the backend
-  const apiUrl = `/api/w3up-delegation/${client.agent.did()}`;
-  const response = await fetch(apiUrl);
-  const data = await response.arrayBuffer();
+  const apiUrl = `/api/w3up-delegation/${client.agent.did()}`
+  const response = await fetch(apiUrl)
+  const data = await response.arrayBuffer()
 
   // Deserialize the delegation
-  const delegation = await Delegation.extract(new Uint8Array(data));
+  const delegation = await Delegation.extract(new Uint8Array(data))
   if (!delegation.ok) {
-    throw new Error("Failed to extract delegation", {
-      cause: delegation.error,
-    });
+    throw new Error('Failed to extract delegation', { cause: delegation.error })
   }
 
   // Add proof that this agent has been delegated capabilities on the space
-  const space = await client.addSpace(delegation.ok);
-  client.setCurrentSpace(space.did());
+  const space = await client.addSpace(delegation.ok)
+  client.setCurrentSpace(space.did())
 
   // READY to go!
 }
@@ -173,10 +153,7 @@ User-\>\>storacha w3up service: Upload data using w3up-client
 If you want your user to own their own Space, you'll typically be relying on the `w3up-client` methods to create a Space, authorize the Space, and authorize the Agent on the user-side; afterwards they can run any of the upload methods.
 
 <Callout type="info">
-  This does not provide visibility over which users are uploading what; to track
-  this, you'll need to share that information separately (e.g., once they've run
-  upload and get back a content CID, you can have them send that CID to you for
-  tracking).
+  This does not provide visibility over which users are uploading what; to track this, you'll need to share that information separately (e.g., once they've run upload and get back a content CID, you can have them send that CID to you for tracking).
 </Callout>
 
 There is a world of possibilities when users "bring their own" Space; you could explore how crypto wallet private keys, Apple Passkey, and more might map to Space DIDs and have the client use those. Your users could delegate capabilities for their space to your backend application or share spaces between friends by delegating to each other.

--- a/src/pages/concepts/architecture-options.mdx
+++ b/src/pages/concepts/architecture-options.mdx
@@ -1,4 +1,4 @@
-import { Callout } from 'nextra/components'
+import { Callout } from "nextra/components";
 
 # Possible architectures using Storacha to upload
 
@@ -25,7 +25,11 @@ w3up-client in backend-\>\>storacha w3up service: Upload data
 You'll need a registered Space, and your client in the backend to have a delegation to use the Space.
 
 <Callout>
-  **Recommended**: It's easiest to create and register your Space using [w3cli](https://github.com/storacha/w3cli), then create an identity for your server and delegate it the ability to upload to your Space. The [bring your own delegations](/how-to/upload/#bring-your-own-delegations) section shows how to generate an identity, create a delegation and then use it on the server.
+  **Recommended**: It's easiest to create and register your Space using
+  [w3cli](https://github.com/storacha/w3cli), then create an identity for your
+  server and delegate it the ability to upload to your Space. The [bring your
+  own delegations](/how-to/upload/#bring-your-own-delegations) section shows how
+  to generate an identity, create a delegation and then use it on the server.
 </Callout>
 
 After this, once your user uploads data to your backend, you can run any of the upload methods.
@@ -53,14 +57,18 @@ Typically `w3up-client` will be running in your end-user's client code, as well 
 You'll need a registered Space, and your client in the backend to have a delegation to use the Space.
 
 <Callout>
-  **Recommended**: It's easiest to create and register your Space using [w3cli](https://github.com/storacha/w3cli), then create an identity for your server and delegate it the ability to upload to your Space. The [bring your own delegations](/how-to/upload/#bring-your-own-delegations) section shows how to generate an identity, create a delegation and then use it on the server.
+  **Recommended**: It's easiest to create and register your Space using
+  [w3cli](https://github.com/storacha/w3cli), then create an identity for your
+  server and delegate it the ability to upload to your Space. The [bring your
+  own delegations](/how-to/upload/#bring-your-own-delegations) section shows how
+  to generate an identity, create a delegation and then use it on the server.
 </Callout>
 
 Your backend code can then re-delegate it's capabilities to your users. Your user does not need a registered Space - just an Agent with a delegation from your Space.
 
 When your user is ready to upload, they should request a delegation from your backend to upload to your Space. They must send their Agent DID so that the delegation is restricted to be used by only them.
 
-In your backend, you can call [`client.createDelegation(...)`](https://github.com/storacha/w3up/blob/main/packages/w3up-client/README.md#createdelegation) passing in the Agent object from `client.agent()` in your end user's instance, and passing params to limit the scope of the delegation (e.g., `space/blob/add`, `upload/add`, expiration time)
+In your backend, you can call [`client.createDelegation(...)`](https://github.com/storacha/w3up/blob/main/packages/w3up-client/README.md#createdelegation) passing in the Agent object from `client.agent` in your end user's instance, and passing params to limit the scope of the delegation (e.g., `space/blob/add`, `upload/add`, expiration time)
 
 You can serialize the delegation using `delegation.archive()` and send it to your user.
 
@@ -69,7 +77,10 @@ The client the user is using does not need to call `client.login(email)`, as it 
 When your user receives the delegation, they can deserialize it using [`Delegation.extract()`](https://github.com/storacha/ucanto/blob/c8999a59852b61549d163532a83bac62290b629d/packages/core/src/delegation.js#L399) and pass it in using `client.addSpace()`, and from there they can run any of the upload methods.
 
 <Callout type="info">
-  This does not provide visibility over which users are uploading what; to track this, you'll need to share that information separately (e.g., once they've run upload and get back a content CID, you can have them send that CID to you for tracking).
+  This does not provide visibility over which users are uploading what; to track
+  this, you'll need to share that information separately (e.g., once they've run
+  upload and get back a content CID, you can have them send that CID to you for
+  tracking).
 </Callout>
 
 A code example that does this can be found below:
@@ -77,59 +88,68 @@ A code example that does this can be found below:
 **Backend**
 
 ```js
-import * as Client from '@web3-storage/w3up-client'
-import { StoreMemory } from '@web3-storage/w3up-client/stores/memory'
-import * as Proof from '@web3-storage/w3up-client/proof'
-import { Signer } from '@web3-storage/w3up-client/principal/ed25519'
-import * as DID from '@ipld/dag-ucan/did'
+import * as Client from "@web3-storage/w3up-client";
+import { StoreMemory } from "@web3-storage/w3up-client/stores/memory";
+import * as Proof from "@web3-storage/w3up-client/proof";
+import { Signer } from "@web3-storage/w3up-client/principal/ed25519";
+import * as DID from "@ipld/dag-ucan/did";
 
 async function backend(did) {
   // Load client with specific private key
-  const principal = Signer.parse(process.env.KEY)
-  const store = new StoreMemory()
-  const client = await Client.create({ principal, store })
+  const principal = Signer.parse(process.env.KEY);
+  const store = new StoreMemory();
+  const client = await Client.create({ principal, store });
 
   // Add proof that this agent has been delegated capabilities on the space
-  const proof = await Proof.parse(process.env.PROOF)
-  const space = await client.addSpace(proof)
-  await client.setCurrentSpace(space.did())
+  const proof = await Proof.parse(process.env.PROOF);
+  const space = await client.addSpace(proof);
+  await client.setCurrentSpace(space.did());
 
   // Create a delegation for a specific DID
-  const audience = DID.parse(did)
-  const abilities = ['space/blob/add', 'space/index/add', 'filecoin/offer', 'upload/add']
-  const expiration = Math.floor(Date.now() / 1000) + (60 * 60 * 24) // 24 hours from now
-  const delegation = await client.createDelegation(audience, abilities, { expiration })
+  const audience = DID.parse(did);
+  const abilities = [
+    "space/blob/add",
+    "space/index/add",
+    "filecoin/offer",
+    "upload/add",
+  ];
+  const expiration = Math.floor(Date.now() / 1000) + 60 * 60 * 24; // 24 hours from now
+  const delegation = await client.createDelegation(audience, abilities, {
+    expiration,
+  });
 
   // Serialize the delegation and send it to the client
-  const archive = await delegation.archive()
-  return archive.ok
+  const archive = await delegation.archive();
+  return archive.ok;
 }
 ```
 
 **Frontend**
 
 ```js
-import * as Delegation from '@web3-storage/w3up-client/delegation'
-import * as Client from '@web3-storage/w3up-client'
+import * as Delegation from "@web3-storage/w3up-client/delegation";
+import * as Client from "@web3-storage/w3up-client";
 
 async function frontend() {
   // Create a new client
-  const client = await Client.create()
+  const client = await Client.create();
 
   // Fetch the delegation from the backend
-  const apiUrl = `/api/w3up-delegation/${client.agent().did()}`
-  const response = await fetch(apiUrl)
-  const data = await response.arrayBuffer()
+  const apiUrl = `/api/w3up-delegation/${client.agent.did()}`;
+  const response = await fetch(apiUrl);
+  const data = await response.arrayBuffer();
 
   // Deserialize the delegation
-  const delegation = await Delegation.extract(new Uint8Array(data))
+  const delegation = await Delegation.extract(new Uint8Array(data));
   if (!delegation.ok) {
-    throw new Error('Failed to extract delegation', { cause: delegation.error })
+    throw new Error("Failed to extract delegation", {
+      cause: delegation.error,
+    });
   }
 
   // Add proof that this agent has been delegated capabilities on the space
-  const space = await client.addSpace(delegation.ok)
-  client.setCurrentSpace(space.did())
+  const space = await client.addSpace(delegation.ok);
+  client.setCurrentSpace(space.did());
 
   // READY to go!
 }
@@ -153,7 +173,10 @@ User-\>\>storacha w3up service: Upload data using w3up-client
 If you want your user to own their own Space, you'll typically be relying on the `w3up-client` methods to create a Space, authorize the Space, and authorize the Agent on the user-side; afterwards they can run any of the upload methods.
 
 <Callout type="info">
-  This does not provide visibility over which users are uploading what; to track this, you'll need to share that information separately (e.g., once they've run upload and get back a content CID, you can have them send that CID to you for tracking).
+  This does not provide visibility over which users are uploading what; to track
+  this, you'll need to share that information separately (e.g., once they've run
+  upload and get back a content CID, you can have them send that CID to you for
+  tracking).
 </Callout>
 
 There is a world of possibilities when users "bring their own" Space; you could explore how crypto wallet private keys, Apple Passkey, and more might map to Space DIDs and have the client use those. Your users could delegate capabilities for their space to your backend application or share spaces between friends by delegating to each other.

--- a/src/pages/concepts/ucans-and-storacha.md
+++ b/src/pages/concepts/ucans-and-storacha.md
@@ -31,50 +31,43 @@ Just like Spaces can delegate permissions to Agents you own, you can also delega
 **Backend**
 
 ```js
-import { CarReader } from "@ipld/car";
-import * as DID from "@ipld/dag-ucan/did";
-import * as Delegation from "@ucanto/core/delegation";
-import * as Signer from "@ucanto/principal/ed25519";
-import * as Client from "@web3-storage/w3up-client";
-import { StoreMemory } from "@web3-storage/w3up-client/stores/memory";
+import { CarReader } from '@ipld/car'
+import * as DID from '@ipld/dag-ucan/did'
+import * as Delegation from '@ucanto/core/delegation'
+import * as Signer from '@ucanto/principal/ed25519'
+import * as Client from '@web3-storage/w3up-client'
+import { StoreMemory } from '@web3-storage/w3up-client/stores/memory'
 
 async function backend(did) {
   // Load client with specific private key
-  const principal = Signer.parse(process.env.KEY);
-  const store = new StoreMemory();
-  const client = await Client.create({ principal, store });
+  const principal = Signer.parse(process.env.KEY)
+  const store = new StoreMemory()
+  const client = await Client.create({ principal, store })
 
   // Add proof that this agent has been delegated capabilities on the space
-  const proof = await parseProof(process.env.PROOF);
-  const space = await client.addSpace(proof);
-  await client.setCurrentSpace(space.did());
+  const proof = await parseProof(process.env.PROOF)
+  const space = await client.addSpace(proof)
+  await client.setCurrentSpace(space.did())
 
   // Create a delegation for a specific DID
-  const audience = DID.parse(did);
-  const abilities = [
-    "space/blob/add",
-    "space/index/add",
-    "filecoin/offer",
-    "upload/add",
-  ];
-  const expiration = Math.floor(Date.now() / 1000) + 60 * 60 * 24; // 24 hours from now
-  const delegation = await client.createDelegation(audience, abilities, {
-    expiration,
-  });
+  const audience = DID.parse(did)
+  const abilities = ['space/blob/add', 'space/index/add', 'filecoin/offer', 'upload/add']
+  const expiration = Math.floor(Date.now() / 1000) + (60 * 60 * 24) // 24 hours from now
+  const delegation = await client.createDelegation(audience, abilities, { expiration })
 
   // Serialize the delegation and send it to the client
-  const archive = await delegation.archive();
-  return archive.ok;
+  const archive = await delegation.archive()
+  return archive.ok
 }
 
 /** @param {string} data Base64 encoded CAR file */
 async function parseProof(data) {
-  const blocks = [];
-  const reader = await CarReader.fromBytes(Buffer.from(data, "base64"));
+  const blocks = []
+  const reader = await CarReader.fromBytes(Buffer.from(data, 'base64'))
   for await (const block of reader.blocks()) {
-    blocks.push(block);
+    blocks.push(block)
   }
-  return Delegation.importDAG(blocks);
+  return Delegation.importDAG(blocks)
 }
 ```
 
@@ -87,29 +80,27 @@ When the `backend` function is called in the developer's backend:
 **Frontend**
 
 ```js
-import * as Delegation from "@ucanto/core/delegation";
-import * as Client from "@web3-storage/w3up-client";
+import * as Delegation from '@ucanto/core/delegation'
+import * as Client from '@web3-storage/w3up-client'
 
 async function frontend() {
   // Create a new client
-  const client = await Client.create();
+  const client = await Client.create()
 
   // Fetch the delegation from the backend
-  const apiUrl = `/api/w3up-delegation/${client.agent.did()}`;
-  const response = await fetch(apiUrl);
-  const data = await response.arrayBuffer();
+  const apiUrl = `/api/w3up-delegation/${client.agent.did()}`
+  const response = await fetch(apiUrl)
+  const data = await response.arrayBuffer()
 
   // Deserialize the delegation
-  const delegation = await Delegation.extract(new Uint8Array(data));
+  const delegation = await Delegation.extract(new Uint8Array(data))
   if (!delegation.ok) {
-    throw new Error("Failed to extract delegation", {
-      cause: delegation.error,
-    });
+    throw new Error('Failed to extract delegation', { cause: delegation.error })
   }
 
   // Add proof that this agent has been delegated capabilities on the space
-  const space = await client.addSpace(delegation.ok);
-  client.setCurrentSpace(space.did());
+  const space = await client.addSpace(delegation.ok)
+  client.setCurrentSpace(space.did())
 
   // READY to go!
 }

--- a/src/pages/concepts/ucans-and-storacha.md
+++ b/src/pages/concepts/ucans-and-storacha.md
@@ -31,43 +31,50 @@ Just like Spaces can delegate permissions to Agents you own, you can also delega
 **Backend**
 
 ```js
-import { CarReader } from '@ipld/car'
-import * as DID from '@ipld/dag-ucan/did'
-import * as Delegation from '@ucanto/core/delegation'
-import * as Signer from '@ucanto/principal/ed25519'
-import * as Client from '@web3-storage/w3up-client'
-import { StoreMemory } from '@web3-storage/w3up-client/stores/memory'
+import { CarReader } from "@ipld/car";
+import * as DID from "@ipld/dag-ucan/did";
+import * as Delegation from "@ucanto/core/delegation";
+import * as Signer from "@ucanto/principal/ed25519";
+import * as Client from "@web3-storage/w3up-client";
+import { StoreMemory } from "@web3-storage/w3up-client/stores/memory";
 
 async function backend(did) {
   // Load client with specific private key
-  const principal = Signer.parse(process.env.KEY)
-  const store = new StoreMemory()
-  const client = await Client.create({ principal, store })
+  const principal = Signer.parse(process.env.KEY);
+  const store = new StoreMemory();
+  const client = await Client.create({ principal, store });
 
   // Add proof that this agent has been delegated capabilities on the space
-  const proof = await parseProof(process.env.PROOF)
-  const space = await client.addSpace(proof)
-  await client.setCurrentSpace(space.did())
+  const proof = await parseProof(process.env.PROOF);
+  const space = await client.addSpace(proof);
+  await client.setCurrentSpace(space.did());
 
   // Create a delegation for a specific DID
-  const audience = DID.parse(did)
-  const abilities = ['space/blob/add', 'space/index/add', 'filecoin/offer', 'upload/add']
-  const expiration = Math.floor(Date.now() / 1000) + (60 * 60 * 24) // 24 hours from now
-  const delegation = await client.createDelegation(audience, abilities, { expiration })
+  const audience = DID.parse(did);
+  const abilities = [
+    "space/blob/add",
+    "space/index/add",
+    "filecoin/offer",
+    "upload/add",
+  ];
+  const expiration = Math.floor(Date.now() / 1000) + 60 * 60 * 24; // 24 hours from now
+  const delegation = await client.createDelegation(audience, abilities, {
+    expiration,
+  });
 
   // Serialize the delegation and send it to the client
-  const archive = await delegation.archive()
-  return archive.ok
+  const archive = await delegation.archive();
+  return archive.ok;
 }
 
 /** @param {string} data Base64 encoded CAR file */
 async function parseProof(data) {
-  const blocks = []
-  const reader = await CarReader.fromBytes(Buffer.from(data, 'base64'))
+  const blocks = [];
+  const reader = await CarReader.fromBytes(Buffer.from(data, "base64"));
   for await (const block of reader.blocks()) {
-    blocks.push(block)
+    blocks.push(block);
   }
-  return Delegation.importDAG(blocks)
+  return Delegation.importDAG(blocks);
 }
 ```
 
@@ -80,27 +87,29 @@ When the `backend` function is called in the developer's backend:
 **Frontend**
 
 ```js
-import * as Delegation from '@ucanto/core/delegation'
-import * as Client from '@web3-storage/w3up-client'
+import * as Delegation from "@ucanto/core/delegation";
+import * as Client from "@web3-storage/w3up-client";
 
 async function frontend() {
   // Create a new client
-  const client = await Client.create()
+  const client = await Client.create();
 
   // Fetch the delegation from the backend
-  const apiUrl = `/api/w3up-delegation/${client.agent().did()}`
-  const response = await fetch(apiUrl)
-  const data = await response.arrayBuffer()
+  const apiUrl = `/api/w3up-delegation/${client.agent.did()}`;
+  const response = await fetch(apiUrl);
+  const data = await response.arrayBuffer();
 
   // Deserialize the delegation
-  const delegation = await Delegation.extract(new Uint8Array(data))
+  const delegation = await Delegation.extract(new Uint8Array(data));
   if (!delegation.ok) {
-    throw new Error('Failed to extract delegation', { cause: delegation.error })
+    throw new Error("Failed to extract delegation", {
+      cause: delegation.error,
+    });
   }
 
   // Add proof that this agent has been delegated capabilities on the space
-  const space = await client.addSpace(delegation.ok)
-  client.setCurrentSpace(space.did())
+  const space = await client.addSpace(delegation.ok);
+  client.setCurrentSpace(space.did());
 
   // READY to go!
 }

--- a/src/pages/how-to/upload.mdx
+++ b/src/pages/how-to/upload.mdx
@@ -1,4 +1,4 @@
-import { Callout } from "nextra/components";
+import { Callout } from 'nextra/components'
 
 # How to upload data using Storacha
 
@@ -7,21 +7,13 @@ In this how-to guide, you'll learn how to store data programmatically for your d
 Later in this section, we also cover uploading data using the CLI or web console. If you just want to quickly store a few files using Storacha rather than include upload functionality in an app or service you're building, you may want to hop down there.
 
 <Callout type="error" emoji="⚠️❗">
-  **Public Data 🌎**
-  <br />
-  All data uploaded to w3up is available to anyone who requests it using the
-  correct CID. Do not store any private or sensitive information in an
-  unencrypted form using w3up.
+  **Public Data 🌎**<br/>
+  All data uploaded to w3up is available to anyone who requests it using the correct CID. Do not store any private or sensitive information in an unencrypted form using w3up.
 </Callout>
 
 <Callout type="error" emoji="⚠️❗">
-  **Permanent Data ♾️**
-  <br />
-  Removing files from w3up will remove them from the file listing for your
-  account, but that doesn't prevent nodes on the decentralized storage network
-  from retaining copies of the data indefinitely. Storacha itself generally
-  retains and charges users for any uploaded data for a minimum of 30 days. Do
-  not use w3up for data that may need to be permanently deleted in the future.
+  **Permanent Data ♾️**<br/>
+  Removing files from w3up will remove them from the file listing for your account, but that doesn't prevent nodes on the decentralized storage network from retaining copies of the data indefinitely. Storacha itself generally retains and charges users for any uploaded data for a minimum of 30 days. Do not use w3up for data that may need to be permanently deleted in the future.
 </Callout>
 
 ## Using the CLI
@@ -70,7 +62,9 @@ Examples of **ephemeral** environments:
 
 #### Claim delegations via email validation
 
-<Callout type="warning">For persistent environment only</Callout>
+<Callout type="warning">
+  For persistent environment only
+</Callout>
 
 A new client can claim access to their existing Spaces by validating their email address.
 
@@ -87,8 +81,8 @@ You can use Storacha's email authorization flow to give permissions to your clie
 When a Space is created, access permissions are delegated to your email address. We use a special kind of DID for this, a `did:mailto:`. These UCANs are stashed with the Storacha service. When you validate your email address with a new Agent DID, Storacha issues a UCAN attestation, that says your Agent DID is owned by your email address. It also returns the UCAN permissions you previously stashed. You can then use the returned UCANs, along with the attestation to prove you are authorized to perform actions.
 
 ```javascript
-import { create } from "@web3-storage/w3up-client";
-const client = await create();
+import { create } from '@web3-storage/w3up-client'
+const client = await create()
 ```
 
 By default, constructing a client like this will re-use state persisted by other clients because `create` constructs the client with a store that persists data between processes and client instances.
@@ -96,13 +90,13 @@ By default, constructing a client like this will re-use state persisted by other
 Once you have created a client, you can login with your email address. Calling login will cause an email to be sent to the given address.
 
 ```javascript
-await client.login("zaphod@beeblebrox.galaxy");
+await client.login('zaphod@beeblebrox.galaxy')
 ```
 
 Once a user clicks the confirmation link in the email, the login method will resolve. Make sure to check for errors, as login will fail if the email is not confirmed within the expiration timeout. Authorization needs to happen only once per agent. This also claims all delegations available with your email address, so from there, you can select the Space you'd like to use.
 
 ```javascript
-await client.setCurrentSpace("did:key:..."); // select the relevant Space DID that is associated with your account
+await client.setCurrentSpace('did:key:...') // select the relevant Space DID that is associated with your account
 ```
 
 #### Bring your own delegations
@@ -145,20 +139,20 @@ w3 delegation create <did_from_ucan-key_command_above> --base64
 Then, when you initialize and configure the client, you can pass in this private key and UCAN delegation.
 
 ```javascript
-import * as Client from "@web3-storage/w3up-client";
-import { StoreMemory } from "@web3-storage/w3up-client/stores/memory";
-import * as Proof from "@web3-storage/w3up-client/proof";
-import { Signer } from "@web3-storage/w3up-client/principal/ed25519";
+import * as Client from '@web3-storage/w3up-client'
+import { StoreMemory } from '@web3-storage/w3up-client/stores/memory'
+import * as Proof from '@web3-storage/w3up-client/proof'
+import { Signer } from '@web3-storage/w3up-client/principal/ed25519'
 
-async function main() {
+async function main () {
   // Load client with specific private key
-  const principal = Signer.parse(process.env.KEY);
-  const store = new StoreMemory();
-  const client = await Client.create({ principal, store });
+  const principal = Signer.parse(process.env.KEY)
+  const store = new StoreMemory()
+  const client = await Client.create({ principal, store })
   // Add proof that this agent has been delegated capabilities on the space
-  const proof = await Proof.parse(process.env.PROOF);
-  const space = await client.addSpace(proof);
-  await client.setCurrentSpace(space.did());
+  const proof = await Proof.parse(process.env.PROOF)
+  const space = await client.addSpace(proof)
+  await client.setCurrentSpace(space.did())
   // READY to go!
 }
 ```
@@ -183,15 +177,15 @@ Application Backend-\>\>storacha service: Upload data
 You are already set up to upload using your client instance as data becomes available to your backend - you can call `uploadFile` or `uploadDirectory` with it.
 
 ```javascript
-import { create } from "@web3-storage/w3up-client";
-import { filesFromPaths } from "files-from-path";
+import { create } from '@web3-storage/w3up-client'
+import { filesFromPaths } from 'files-from-path'
 
 // e.g "./best-gifs"
-const path = process.env.PATH_TO_FILES;
-const files = await filesFromPaths([path]);
+const path = process.env.PATH_TO_FILES
+const files = await filesFromPaths([path])
 
-const client = await create();
-const directoryCid = await client.uploadDirectory(files);
+const client = await create()
+const directoryCid = await client.uploadDirectory(files)
 ```
 
 In the example above, `directoryCid` resolves to an IPFS directory.
@@ -214,68 +208,59 @@ Your backend instance can also be used to delegate upload permissions directly t
 **Backend**
 
 ```js
-import * as Client from "@web3-storage/w3up-client";
-import { StoreMemory } from "@web3-storage/w3up-client/stores/memory";
-import * as Proof from "@web3-storage/w3up-client/proof";
-import { Signer } from "@web3-storage/w3up-client/principal/ed25519";
-import * as DID from "@ipld/dag-ucan/did";
+import * as Client from '@web3-storage/w3up-client'
+import { StoreMemory } from '@web3-storage/w3up-client/stores/memory'
+import * as Proof from '@web3-storage/w3up-client/proof'
+import { Signer } from '@web3-storage/w3up-client/principal/ed25519'
+import * as DID from '@ipld/dag-ucan/did'
 
 async function backend(did) {
   // Load client with specific private key
-  const principal = Signer.parse(process.env.KEY);
-  const store = new StoreMemory();
-  const client = await Client.create({ principal, store });
+  const principal = Signer.parse(process.env.KEY)
+  const store = new StoreMemory()
+  const client = await Client.create({ principal, store })
 
   // Add proof that this agent has been delegated capabilities on the space
-  const proof = await Proof.parse(process.env.PROOF);
-  const space = await client.addSpace(proof);
-  await client.setCurrentSpace(space.did());
+  const proof = await Proof.parse(process.env.PROOF)
+  const space = await client.addSpace(proof)
+  await client.setCurrentSpace(space.did())
 
   // Create a delegation for a specific DID
-  const audience = DID.parse(did);
-  const abilities = [
-    "space/blob/add",
-    "space/index/add",
-    "filecoin/offer",
-    "upload/add",
-  ];
-  const expiration = Math.floor(Date.now() / 1000) + 60 * 60 * 24; // 24 hours from now
-  const delegation = await client.createDelegation(audience, abilities, {
-    expiration,
-  });
+  const audience = DID.parse(did)
+  const abilities = ['space/blob/add', 'space/index/add', 'filecoin/offer', 'upload/add']
+  const expiration = Math.floor(Date.now() / 1000) + (60 * 60 * 24) // 24 hours from now
+  const delegation = await client.createDelegation(audience, abilities, { expiration })
 
   // Serialize the delegation and send it to the client
-  const archive = await delegation.archive();
-  return archive.ok;
+  const archive = await delegation.archive()
+  return archive.ok
 }
 ```
 
 **Frontend**
 
 ```js
-import * as Delegation from "@web3-storage/w3up-client/delegation";
-import * as Client from "@web3-storage/w3up-client";
+import * as Delegation from '@web3-storage/w3up-client/delegation'
+import * as Client from '@web3-storage/w3up-client'
 
 async function frontend() {
   // Create a new client
-  const client = await Client.create();
+  const client = await Client.create()
 
   // Fetch the delegation from the backend
-  const apiUrl = `/api/w3up-delegation/${client.agent.did()}`;
-  const response = await fetch(apiUrl);
-  const data = await response.arrayBuffer();
+  const apiUrl = `/api/w3up-delegation/${client.agent.did()}`
+  const response = await fetch(apiUrl)
+  const data = await response.arrayBuffer()
 
   // Deserialize the delegation
-  const delegation = await Delegation.extract(new Uint8Array(data));
+  const delegation = await Delegation.extract(new Uint8Array(data))
   if (!delegation.ok) {
-    throw new Error("Failed to extract delegation", {
-      cause: delegation.error,
-    });
+    throw new Error('Failed to extract delegation', { cause: delegation.error })
   }
 
   // Add proof that this agent has been delegated capabilities on the space
-  const space = await client.addSpace(delegation.ok);
-  client.setCurrentSpace(space.did());
+  const space = await client.addSpace(delegation.ok)
+  client.setCurrentSpace(space.did())
 
   // READY to go!
 }
@@ -290,22 +275,19 @@ You are now ready to upload using the client! In general, the easiest way to upl
 `uploadDirectory` requires `File`-like objects instead of `Blob`s, as the file's name property is used to build the directory hierarchy.
 
 <Callout>
-  When uploading multiple files, give each file a unique name. All the files in
-  a `uploadDirectory` request will be bundled into one content archive, and
-  linking to the files inside is much easier if each file has a unique,
-  human-readable name.
+  When uploading multiple files, give each file a unique name. All the files in a `uploadDirectory` request will be bundled into one content archive, and linking to the files inside is much easier if each file has a unique, human-readable name.
 </Callout>
 
 You can control the directory layout and create nested directory structures by using / delimited paths in your filenames:
 
 ```javascript
 const files = [
-  new File(["some-file-content"], "readme.md"),
-  new File(["import foo"], "src/main.py"),
-  new File([someBinaryData], "images/example.png"),
-];
+  new File(['some-file-content'], 'readme.md'),
+  new File(['import foo'], 'src/main.py'),
+  new File([someBinaryData], 'images/example.png'),
+]
 
-const directoryCid = await client.uploadDirectory(files);
+const directoryCid = await client.uploadDirectory(files)
 ```
 
 In the example above, directoryCid resolves to an IPFS directory with the following layout:
@@ -324,58 +306,58 @@ There are a few different ways of creating `File` objects available, depending o
 In the browser, you can use a [file input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file) to allow the user to select files for upload:
 
 ```javascript
-function getFiles() {
-  const fileInput = document.querySelector('input[type="file"]');
-  return fileInput.files;
+function getFiles () {
+  const fileInput = document.querySelector('input[type="file"]')
+  return fileInput.files
 }
 ```
 
 You can also manually create File objects using the native File constructor provided by the browser runtime. This is useful when you want to store data created by your application, instead of files from the user's computer.
 
 ```javascript
-function makeFileObjects() {
+function makeFileObjects () {
   // You can create File objects from a Blob of binary data
   // see: https://developer.mozilla.org/en-US/docs/Web/API/Blob
   // Here we're just storing a JSON object, but you can store images,
   // audio, or whatever you want!
-  const obj = { hello: "world" };
-  const blob = new Blob([JSON.stringify(obj)], { type: "application/json" });
+  const obj = { hello: 'world' }
+  const blob = new Blob([JSON.stringify(obj)], { type: 'application/json' })
 
   const files = [
-    new File(["contents-of-file-1"], "plain-utf8.txt"),
-    new File([blob], "hello.json"),
-  ];
-  return files;
+    new File(['contents-of-file-1'], 'plain-utf8.txt'),
+    new File([blob], 'hello.json')
+  ]
+  return files
 }
 ```
 
 In Node.js, the [`files-from-path` library](https://github.com/storacha/files-from-path) reads File objects from the local file system. The `filesFromPaths` helper asynchronously returns an array of Files that you can use directly with the `uploadDirectory` client method:
 
 ```javascript
-import { filesFromPaths } from "files-from-path";
+import { filesFromPaths } from 'files-from-path'
 ```
 
 You can also manually create File objects by importing a Node.js implementation of File from the Storacha package. This is useful when you want to store data created by your application, instead of files from the user's computer.
 
 ```javascript
-async function getFiles(path) {
-  const files = await filesFromPaths([path]);
-  console.log(`read ${files.length} file(s) from ${path}`);
-  return files;
+async function getFiles (path) {
+  const files = await filesFromPaths([path])
+  console.log(`read ${files.length} file(s) from ${path}`)
+  return files
 }
 
-function makeFileObjects() {
+function makeFileObjects () {
   // You can create File objects from a Buffer of binary data
   // see: https://nodejs.org/api/buffer.html
   // Here we're just storing a JSON object, but you can store images,
   // audio, or whatever you want!
-  const obj = { hello: "world" };
-  const buffer = Buffer.from(JSON.stringify(obj));
+  const obj = { hello: 'world' }
+  const buffer = Buffer.from(JSON.stringify(obj))
   const files = [
-    new File(["contents-of-file-1"], "plain-utf8.txt"),
-    new File([buffer], "hello.json"),
-  ];
-  return files;
+    new File(['contents-of-file-1'], 'plain-utf8.txt'),
+    new File([buffer], 'hello.json')
+  ]
+  return files
 }
 ```
 

--- a/src/pages/how-to/upload.mdx
+++ b/src/pages/how-to/upload.mdx
@@ -1,4 +1,4 @@
-import { Callout } from 'nextra/components'
+import { Callout } from "nextra/components";
 
 # How to upload data using Storacha
 
@@ -7,13 +7,21 @@ In this how-to guide, you'll learn how to store data programmatically for your d
 Later in this section, we also cover uploading data using the CLI or web console. If you just want to quickly store a few files using Storacha rather than include upload functionality in an app or service you're building, you may want to hop down there.
 
 <Callout type="error" emoji="⚠️❗">
-  **Public Data 🌎**<br/>
-  All data uploaded to w3up is available to anyone who requests it using the correct CID. Do not store any private or sensitive information in an unencrypted form using w3up.
+  **Public Data 🌎**
+  <br />
+  All data uploaded to w3up is available to anyone who requests it using the
+  correct CID. Do not store any private or sensitive information in an
+  unencrypted form using w3up.
 </Callout>
 
 <Callout type="error" emoji="⚠️❗">
-  **Permanent Data ♾️**<br/>
-  Removing files from w3up will remove them from the file listing for your account, but that doesn't prevent nodes on the decentralized storage network from retaining copies of the data indefinitely. Storacha itself generally retains and charges users for any uploaded data for a minimum of 30 days. Do not use w3up for data that may need to be permanently deleted in the future.
+  **Permanent Data ♾️**
+  <br />
+  Removing files from w3up will remove them from the file listing for your
+  account, but that doesn't prevent nodes on the decentralized storage network
+  from retaining copies of the data indefinitely. Storacha itself generally
+  retains and charges users for any uploaded data for a minimum of 30 days. Do
+  not use w3up for data that may need to be permanently deleted in the future.
 </Callout>
 
 ## Using the CLI
@@ -62,9 +70,7 @@ Examples of **ephemeral** environments:
 
 #### Claim delegations via email validation
 
-<Callout type="warning">
-  For persistent environment only
-</Callout>
+<Callout type="warning">For persistent environment only</Callout>
 
 A new client can claim access to their existing Spaces by validating their email address.
 
@@ -81,8 +87,8 @@ You can use Storacha's email authorization flow to give permissions to your clie
 When a Space is created, access permissions are delegated to your email address. We use a special kind of DID for this, a `did:mailto:`. These UCANs are stashed with the Storacha service. When you validate your email address with a new Agent DID, Storacha issues a UCAN attestation, that says your Agent DID is owned by your email address. It also returns the UCAN permissions you previously stashed. You can then use the returned UCANs, along with the attestation to prove you are authorized to perform actions.
 
 ```javascript
-import { create } from '@web3-storage/w3up-client'
-const client = await create()
+import { create } from "@web3-storage/w3up-client";
+const client = await create();
 ```
 
 By default, constructing a client like this will re-use state persisted by other clients because `create` constructs the client with a store that persists data between processes and client instances.
@@ -90,13 +96,13 @@ By default, constructing a client like this will re-use state persisted by other
 Once you have created a client, you can login with your email address. Calling login will cause an email to be sent to the given address.
 
 ```javascript
-await client.login('zaphod@beeblebrox.galaxy')
+await client.login("zaphod@beeblebrox.galaxy");
 ```
 
 Once a user clicks the confirmation link in the email, the login method will resolve. Make sure to check for errors, as login will fail if the email is not confirmed within the expiration timeout. Authorization needs to happen only once per agent. This also claims all delegations available with your email address, so from there, you can select the Space you'd like to use.
 
 ```javascript
-await client.setCurrentSpace('did:key:...') // select the relevant Space DID that is associated with your account
+await client.setCurrentSpace("did:key:..."); // select the relevant Space DID that is associated with your account
 ```
 
 #### Bring your own delegations
@@ -139,20 +145,20 @@ w3 delegation create <did_from_ucan-key_command_above> --base64
 Then, when you initialize and configure the client, you can pass in this private key and UCAN delegation.
 
 ```javascript
-import * as Client from '@web3-storage/w3up-client'
-import { StoreMemory } from '@web3-storage/w3up-client/stores/memory'
-import * as Proof from '@web3-storage/w3up-client/proof'
-import { Signer } from '@web3-storage/w3up-client/principal/ed25519'
+import * as Client from "@web3-storage/w3up-client";
+import { StoreMemory } from "@web3-storage/w3up-client/stores/memory";
+import * as Proof from "@web3-storage/w3up-client/proof";
+import { Signer } from "@web3-storage/w3up-client/principal/ed25519";
 
-async function main () {
+async function main() {
   // Load client with specific private key
-  const principal = Signer.parse(process.env.KEY)
-  const store = new StoreMemory()
-  const client = await Client.create({ principal, store })
+  const principal = Signer.parse(process.env.KEY);
+  const store = new StoreMemory();
+  const client = await Client.create({ principal, store });
   // Add proof that this agent has been delegated capabilities on the space
-  const proof = await Proof.parse(process.env.PROOF)
-  const space = await client.addSpace(proof)
-  await client.setCurrentSpace(space.did())
+  const proof = await Proof.parse(process.env.PROOF);
+  const space = await client.addSpace(proof);
+  await client.setCurrentSpace(space.did());
   // READY to go!
 }
 ```
@@ -177,15 +183,15 @@ Application Backend-\>\>storacha service: Upload data
 You are already set up to upload using your client instance as data becomes available to your backend - you can call `uploadFile` or `uploadDirectory` with it.
 
 ```javascript
-import { create } from '@web3-storage/w3up-client'
-import { filesFromPaths } from 'files-from-path'
+import { create } from "@web3-storage/w3up-client";
+import { filesFromPaths } from "files-from-path";
 
 // e.g "./best-gifs"
-const path = process.env.PATH_TO_FILES
-const files = await filesFromPaths([path])
+const path = process.env.PATH_TO_FILES;
+const files = await filesFromPaths([path]);
 
-const client = await create()
-const directoryCid = await client.uploadDirectory(files)
+const client = await create();
+const directoryCid = await client.uploadDirectory(files);
 ```
 
 In the example above, `directoryCid` resolves to an IPFS directory.
@@ -208,59 +214,68 @@ Your backend instance can also be used to delegate upload permissions directly t
 **Backend**
 
 ```js
-import * as Client from '@web3-storage/w3up-client'
-import { StoreMemory } from '@web3-storage/w3up-client/stores/memory'
-import * as Proof from '@web3-storage/w3up-client/proof'
-import { Signer } from '@web3-storage/w3up-client/principal/ed25519'
-import * as DID from '@ipld/dag-ucan/did'
+import * as Client from "@web3-storage/w3up-client";
+import { StoreMemory } from "@web3-storage/w3up-client/stores/memory";
+import * as Proof from "@web3-storage/w3up-client/proof";
+import { Signer } from "@web3-storage/w3up-client/principal/ed25519";
+import * as DID from "@ipld/dag-ucan/did";
 
 async function backend(did) {
   // Load client with specific private key
-  const principal = Signer.parse(process.env.KEY)
-  const store = new StoreMemory()
-  const client = await Client.create({ principal, store })
+  const principal = Signer.parse(process.env.KEY);
+  const store = new StoreMemory();
+  const client = await Client.create({ principal, store });
 
   // Add proof that this agent has been delegated capabilities on the space
-  const proof = await Proof.parse(process.env.PROOF)
-  const space = await client.addSpace(proof)
-  await client.setCurrentSpace(space.did())
+  const proof = await Proof.parse(process.env.PROOF);
+  const space = await client.addSpace(proof);
+  await client.setCurrentSpace(space.did());
 
   // Create a delegation for a specific DID
-  const audience = DID.parse(did)
-  const abilities = ['space/blob/add', 'space/index/add', 'filecoin/offer', 'upload/add']
-  const expiration = Math.floor(Date.now() / 1000) + (60 * 60 * 24) // 24 hours from now
-  const delegation = await client.createDelegation(audience, abilities, { expiration })
+  const audience = DID.parse(did);
+  const abilities = [
+    "space/blob/add",
+    "space/index/add",
+    "filecoin/offer",
+    "upload/add",
+  ];
+  const expiration = Math.floor(Date.now() / 1000) + 60 * 60 * 24; // 24 hours from now
+  const delegation = await client.createDelegation(audience, abilities, {
+    expiration,
+  });
 
   // Serialize the delegation and send it to the client
-  const archive = await delegation.archive()
-  return archive.ok
+  const archive = await delegation.archive();
+  return archive.ok;
 }
 ```
 
 **Frontend**
 
 ```js
-import * as Delegation from '@web3-storage/w3up-client/delegation'
-import * as Client from '@web3-storage/w3up-client'
+import * as Delegation from "@web3-storage/w3up-client/delegation";
+import * as Client from "@web3-storage/w3up-client";
 
 async function frontend() {
   // Create a new client
-  const client = await Client.create()
+  const client = await Client.create();
 
   // Fetch the delegation from the backend
-  const apiUrl = `/api/w3up-delegation/${client.agent().did()}`
-  const response = await fetch(apiUrl)
-  const data = await response.arrayBuffer()
+  const apiUrl = `/api/w3up-delegation/${client.agent.did()}`;
+  const response = await fetch(apiUrl);
+  const data = await response.arrayBuffer();
 
   // Deserialize the delegation
-  const delegation = await Delegation.extract(new Uint8Array(data))
+  const delegation = await Delegation.extract(new Uint8Array(data));
   if (!delegation.ok) {
-    throw new Error('Failed to extract delegation', { cause: delegation.error })
+    throw new Error("Failed to extract delegation", {
+      cause: delegation.error,
+    });
   }
 
   // Add proof that this agent has been delegated capabilities on the space
-  const space = await client.addSpace(delegation.ok)
-  client.setCurrentSpace(space.did())
+  const space = await client.addSpace(delegation.ok);
+  client.setCurrentSpace(space.did());
 
   // READY to go!
 }
@@ -275,19 +290,22 @@ You are now ready to upload using the client! In general, the easiest way to upl
 `uploadDirectory` requires `File`-like objects instead of `Blob`s, as the file's name property is used to build the directory hierarchy.
 
 <Callout>
-  When uploading multiple files, give each file a unique name. All the files in a `uploadDirectory` request will be bundled into one content archive, and linking to the files inside is much easier if each file has a unique, human-readable name.
+  When uploading multiple files, give each file a unique name. All the files in
+  a `uploadDirectory` request will be bundled into one content archive, and
+  linking to the files inside is much easier if each file has a unique,
+  human-readable name.
 </Callout>
 
 You can control the directory layout and create nested directory structures by using / delimited paths in your filenames:
 
 ```javascript
 const files = [
-  new File(['some-file-content'], 'readme.md'),
-  new File(['import foo'], 'src/main.py'),
-  new File([someBinaryData], 'images/example.png'),
-]
+  new File(["some-file-content"], "readme.md"),
+  new File(["import foo"], "src/main.py"),
+  new File([someBinaryData], "images/example.png"),
+];
 
-const directoryCid = await client.uploadDirectory(files)
+const directoryCid = await client.uploadDirectory(files);
 ```
 
 In the example above, directoryCid resolves to an IPFS directory with the following layout:
@@ -306,58 +324,58 @@ There are a few different ways of creating `File` objects available, depending o
 In the browser, you can use a [file input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file) to allow the user to select files for upload:
 
 ```javascript
-function getFiles () {
-  const fileInput = document.querySelector('input[type="file"]')
-  return fileInput.files
+function getFiles() {
+  const fileInput = document.querySelector('input[type="file"]');
+  return fileInput.files;
 }
 ```
 
 You can also manually create File objects using the native File constructor provided by the browser runtime. This is useful when you want to store data created by your application, instead of files from the user's computer.
 
 ```javascript
-function makeFileObjects () {
+function makeFileObjects() {
   // You can create File objects from a Blob of binary data
   // see: https://developer.mozilla.org/en-US/docs/Web/API/Blob
   // Here we're just storing a JSON object, but you can store images,
   // audio, or whatever you want!
-  const obj = { hello: 'world' }
-  const blob = new Blob([JSON.stringify(obj)], { type: 'application/json' })
+  const obj = { hello: "world" };
+  const blob = new Blob([JSON.stringify(obj)], { type: "application/json" });
 
   const files = [
-    new File(['contents-of-file-1'], 'plain-utf8.txt'),
-    new File([blob], 'hello.json')
-  ]
-  return files
+    new File(["contents-of-file-1"], "plain-utf8.txt"),
+    new File([blob], "hello.json"),
+  ];
+  return files;
 }
 ```
 
 In Node.js, the [`files-from-path` library](https://github.com/storacha/files-from-path) reads File objects from the local file system. The `filesFromPaths` helper asynchronously returns an array of Files that you can use directly with the `uploadDirectory` client method:
 
 ```javascript
-import { filesFromPaths } from 'files-from-path'
+import { filesFromPaths } from "files-from-path";
 ```
 
 You can also manually create File objects by importing a Node.js implementation of File from the Storacha package. This is useful when you want to store data created by your application, instead of files from the user's computer.
 
 ```javascript
-async function getFiles (path) {
-  const files = await filesFromPaths([path])
-  console.log(`read ${files.length} file(s) from ${path}`)
-  return files
+async function getFiles(path) {
+  const files = await filesFromPaths([path]);
+  console.log(`read ${files.length} file(s) from ${path}`);
+  return files;
 }
 
-function makeFileObjects () {
+function makeFileObjects() {
   // You can create File objects from a Buffer of binary data
   // see: https://nodejs.org/api/buffer.html
   // Here we're just storing a JSON object, but you can store images,
   // audio, or whatever you want!
-  const obj = { hello: 'world' }
-  const buffer = Buffer.from(JSON.stringify(obj))
+  const obj = { hello: "world" };
+  const buffer = Buffer.from(JSON.stringify(obj));
   const files = [
-    new File(['contents-of-file-1'], 'plain-utf8.txt'),
-    new File([buffer], 'hello.json')
-  ]
-  return files
+    new File(["contents-of-file-1"], "plain-utf8.txt"),
+    new File([buffer], "hello.json"),
+  ];
+  return files;
 }
 ```
 


### PR DESCRIPTION
`client.agent` is an object not a function, so updated docs to enable a working example