### PR TITLE
fix: code snippet in how-to/upload

### DIFF
--- a/src/pages/how-to/upload.mdx
+++ b/src/pages/how-to/upload.mdx
@@ -211,6 +211,7 @@ import { StoreMemory } from '@storacha/client/stores/memory'
 import * as Proof from '@storacha/client/proof'
 import { Signer } from '@storacha/client/principal/ed25519'
 import * as DID from '@ipld/dag-ucan/did'
+import type { ServiceAbility } from '@storacha/client'
 
 async function backend(did) {
   // Load client with specific private key
@@ -225,7 +226,7 @@ async function backend(did) {
 
   // Create a delegation for a specific DID
   const audience = DID.parse(did)
-  const abilities = ['space/blob/add', 'space/index/add', 'filecoin/offer', 'upload/add']
+  const abilities: ServiceAbility[] = ['space/blob/add', 'space/index/add', 'filecoin/offer', 'upload/add']
   const expiration = Math.floor(Date.now() / 1000) + (60 * 60 * 24) // 24 hours from now
   const delegation = await client.createDelegation(audience, abilities, { expiration })
 


### PR DESCRIPTION
issue: #170 

Fixes TypeScript type error in the code snippet at line 228 of docs/src/pages/how-to/upload.mdx by adding explicit type annotation to the abilities array.

**Changes**

1. Added ServiceAbility[] type annotation to the abilities array declaration
2. Added import for ServiceAbility type from @storacha/client
3. Resolves type inference issues that were causing compilation errors